### PR TITLE
ignore encoding errors while reading the file

### DIFF
--- a/src/log_parser.py
+++ b/src/log_parser.py
@@ -34,7 +34,7 @@ class LogParser:
         
     def load_log(self):
         try:
-            with open(self.path_to_raw_log) as raw_log:
+            with open(self.path_to_raw_log, errors='ignore') as raw_log:
                 loaded_log = str(raw_log.read())
                 return loaded_log
         except:


### PR DESCRIPTION
Sometimes we will see the following encoding errors when reading the log file:

UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 485168: invalid start byte

We can just ignore these failures.